### PR TITLE
Add GANG CULTURE WordPress theme

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,6 @@
+<footer class="site-footer">
+    <p>&copy; <?php echo date('Y'); ?> GANG CULTURE</p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,13 @@
+<?php get_header(); ?>
+<div class="parallax">
+    <div class="parallax__layer parallax__layer--back" data-depth="0.2">
+        <img src="<?php echo get_template_directory_uri(); ?>/images/bg-back.jpg" alt="" />
+    </div>
+    <div class="parallax__layer parallax__layer--base" data-depth="0.6">
+        <section class="hero">
+            <h1><?php bloginfo('name'); ?></h1>
+            <p><?php bloginfo('description'); ?></p>
+        </section>
+    </div>
+</div>
+<?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,74 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// Theme setup
+function gangculture_setup() {
+    load_theme_textdomain( 'gangculture', get_template_directory() . '/languages' );
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'woocommerce' );
+    register_nav_menus( array(
+        'primary' => __( 'Primary Menu', 'gangculture' )
+    ) );
+}
+add_action( 'after_setup_theme', 'gangculture_setup' );
+
+// Enqueue scripts and styles
+function gangculture_scripts() {
+    wp_enqueue_style( 'gangculture-style', get_stylesheet_uri(), array(), '1.0' );
+    wp_enqueue_script( 'gangculture-parallax', get_template_directory_uri() . '/js/parallax.js', array('jquery'), '1.0', true );
+}
+add_action( 'wp_enqueue_scripts', 'gangculture_scripts' );
+
+// Custom post type for music singles
+function gangculture_register_single_cpt() {
+    $labels = array(
+        'name' => __( 'Singles', 'gangculture' ),
+        'singular_name' => __( 'Single', 'gangculture' )
+    );
+    $args = array(
+        'labels' => $labels,
+        'public' => true,
+        'supports' => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+        'has_archive' => true,
+        'show_in_rest' => true,
+    );
+    register_post_type( 'single', $args );
+}
+add_action( 'init', 'gangculture_register_single_cpt' );
+
+// Reservation form shortcode
+function gangculture_reservation_shortcode() {
+    ob_start();
+    echo '<div id="reservation-calendar"></div>';
+    echo '<form id="reservation-form">';
+    echo '<label>' . __( 'Date', 'gangculture' ) . '<input type="date" name="res_date" required></label>';
+    echo '<label>' . __( 'Type', 'gangculture' ) . '<select name="res_type"><option>' . __( 'With engineer', 'gangculture' ) . '</option><option>' . __( 'Without engineer', 'gangculture' ) . '</option><option>' . __( 'Space only', 'gangculture' ) . '</option></select></label>';
+    echo '<button class="gang-btn" type="submit">' . __( 'Reserve', 'gangculture' ) . '</button>';
+    echo '</form>';
+    return ob_get_clean();
+}
+add_shortcode( 'gang_reservation', 'gangculture_reservation_shortcode' );
+
+// Simple button shortcode
+function gangculture_button_shortcode( $atts, $content = null ) {
+    return '<a class="gang-btn" href="#">' . do_shortcode( $content ) . '</a>';
+}
+add_shortcode( 'gang_button', 'gangculture_button_shortcode' );
+
+// Graffiti Icon Widget
+class Graffiti_Icon_Widget extends WP_Widget {
+    function __construct() {
+        parent::__construct( 'graffiti_icon', __( 'Graffiti Icon', 'gangculture' ) );
+    }
+    public function widget( $args, $instance ) {
+        echo $args['before_widget'];
+        echo '<span class="graffiti-icon">&#x1F58C;</span>';
+        echo $args['after_widget'];
+    }
+}
+function gangculture_register_widgets() {
+    register_widget( 'Graffiti_Icon_Widget' );
+}
+add_action( 'widgets_init', 'gangculture_register_widgets' );
+?>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="site-header">
+    <nav class="main-nav">
+        <?php wp_nav_menu( array( 'theme_location' => 'primary' ) ); ?>
+    </nav>
+</header>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<main id="main" class="site-main">
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article <?php post_class(); ?>>
+        <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+        <?php the_excerpt(); ?>
+    </article>
+<?php endwhile; endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/js/parallax.js
+++ b/js/parallax.js
@@ -1,0 +1,11 @@
+jQuery(document).ready(function($){
+    var $layers = $('.parallax__layer');
+    $(window).on('scroll', function(){
+        var top = $(this).scrollTop();
+        $layers.each(function(){
+            var depth = $(this).data('depth') || 0;
+            var movement = -(top * depth);
+            $(this).css('transform','translate3d(0,'+movement+'px,0)');
+        });
+    });
+});

--- a/languages/gangculture.pot
+++ b/languages/gangculture.pot
@@ -1,0 +1,26 @@
+msgid "Primary Menu"
+msgstr "Primární menu"
+
+msgid "Singles"
+msgstr "Singly"
+
+msgid "Single"
+msgstr "Singl"
+
+msgid "Date"
+msgstr "Datum"
+
+msgid "Type"
+msgstr "Typ"
+
+msgid "With engineer"
+msgstr "S inženýrem"
+
+msgid "Without engineer"
+msgstr "Bez inženýra"
+
+msgid "Space only"
+msgstr "Pouze prostor"
+
+msgid "Reserve"
+msgstr "Rezervovat"

--- a/page-templates/blog.php
+++ b/page-templates/blog.php
@@ -1,0 +1,12 @@
+<?php /* Template Name: Blog */ get_header(); ?>
+<main class="blog">
+<?php
+query_posts('post_type=post');
+if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <article <?php post_class(); ?>>
+        <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+        <?php the_excerpt(); ?>
+    </article>
+<?php endwhile; endif; wp_reset_query(); ?>
+</main>
+<?php get_footer(); ?>

--- a/page-templates/booking.php
+++ b/page-templates/booking.php
@@ -1,0 +1,5 @@
+<?php /* Template Name: Rezervace */ get_header(); ?>
+<section class="booking">
+<?php echo do_shortcode('[gang_reservation]'); ?>
+</section>
+<?php get_footer(); ?>

--- a/page-templates/contact.php
+++ b/page-templates/contact.php
@@ -1,0 +1,5 @@
+<?php /* Template Name: Kontakt */ get_header(); ?>
+<section class="contact-form">
+<?php echo do_shortcode('[wpforms id="1"]'); ?>
+</section>
+<?php get_footer(); ?>

--- a/page-templates/eshop.php
+++ b/page-templates/eshop.php
@@ -1,0 +1,5 @@
+<?php /* Template Name: E-shop */ get_header(); ?>
+<div class="woocommerce-shop">
+<?php echo do_shortcode('[products]'); ?>
+</div>
+<?php get_footer(); ?>

--- a/page-templates/forum.php
+++ b/page-templates/forum.php
@@ -1,0 +1,5 @@
+<?php /* Template Name: Fórum */ get_header(); ?>
+<div class="bbpress-forum">
+<?php bbp_get_template_part( 'content', 'archive-forum' ); ?>
+</div>
+<?php get_footer(); ?>

--- a/single-single.php
+++ b/single-single.php
@@ -1,0 +1,9 @@
+<?php get_header(); ?>
+<main class="single-music">
+<?php while ( have_posts() ) : the_post(); ?>
+    <h1><?php the_title(); ?></h1>
+    <?php the_content(); ?>
+    <?php if ( get_the_post_thumbnail() ) the_post_thumbnail(); ?>
+<?php endwhile; ?>
+</main>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,72 @@
+/*
+Theme Name: GANG CULTURE
+Theme URI: http://example.com/gangculture
+Author: GANG CULTURE
+Author URI: http://example.com
+Description: Hip hop/graffiti theme with 3D parallax effects, WooCommerce, and custom features.
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: gangculture
+Tags: dark, graffiti, hip-hop, 3d, parallax
+*/
+
+body {
+    background: #111;
+    color: #eee;
+    font-family: 'Helvetica Neue', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Permanent Marker', cursive;
+    color: #0ff;
+}
+
+a {
+    color: #f0f;
+    text-decoration: none;
+}
+
+a:hover {
+    color: #ff0;
+}
+
+.parallax {
+    perspective: 1px;
+    height: 100vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.parallax__layer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+}
+
+.parallax__layer--base {
+    transform: translateZ(0);
+}
+
+.parallax__layer--back {
+    transform: translateZ(-1px) scale(2);
+}
+
+.gang-btn {
+    background: #f0f;
+    color: #000;
+    padding: 10px 20px;
+    display: inline-block;
+    border-radius: 5px;
+    transition: transform 0.3s;
+}
+
+.gang-btn:hover {
+    transform: scale(1.1);
+}
+
+#reservation-calendar {
+    max-width: 600px;
+    margin: 20px auto;
+}


### PR DESCRIPTION
## Summary
- set up hip hop themed style and parallax support
- add theme functions with custom post type, widgets and shortcodes
- create templates for front page, blog, shop, forum, contact and booking
- include basic localization strings
- add simple parallax JavaScript

## Testing
- `php` command was not available so PHP syntax checks could not run

------
https://chatgpt.com/codex/tasks/task_e_685f388290248325abfff2abb3bfd7dd